### PR TITLE
Remove default values for networks

### DIFF
--- a/src/models/modules/discriminators.py
+++ b/src/models/modules/discriminators.py
@@ -6,9 +6,9 @@ import numpy as np
 class Discriminator(nn.Module):
     def __init__(
             self,
-            n_classes: int = 10,
-            channels: int = 1,
-            img_size: int = 32,
+            n_classes: int,
+            channels: int,
+            img_size: int,
     ):
         super().__init__()
         self.img_shape = (channels, img_size, img_size)

--- a/src/models/modules/generators.py
+++ b/src/models/modules/generators.py
@@ -6,10 +6,10 @@ import numpy as np
 class Generator(nn.Module):
     def __init__(
             self,
-            n_classes: int = 10,
-            latent_dim: int = 100,
-            channels: int = 1,
-            img_size: int = 32,
+            n_classes: int,
+            latent_dim: int,
+            channels: int,
+            img_size: int,
     ):
         super().__init__()
         self.img_shape = (channels, img_size, img_size)


### PR DESCRIPTION
This makes sure candidates cannot "cheat" by not specifying any arguments for the networks