### PR TITLE
Restrict Pytorch-lightning's version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # --------- pytorch --------- #
 torch>=1.8.1
 torchvision>=0.9.1
-pytorch-lightning>=1.3.8
+pytorch-lightning==1.5.*
 
 # --------- hydra --------- #
 hydra-core==1.1.0


### PR DESCRIPTION
This is to avoid the logger not iterable error